### PR TITLE
Update registrant_types to pass English values

### DIFF
--- a/resources/domains/additionalfields.php
+++ b/resources/domains/additionalfields.php
@@ -8,14 +8,14 @@
 
 function nordname_registrant_types() {
     return [
-        \Lang::trans('Private Person'),
-        \Lang::trans('Company'),
-        \Lang::trans('Corporation'),
-        \Lang::trans('Institution'),
-        \Lang::trans('Political Party'),
-        \Lang::trans('Township'),
-        \Lang::trans('Government'),
-        \Lang::trans('Public Community')
+        'Private Person|' . \Lang::trans('Private Person'),
+        'Company|' . \Lang::trans('Company'),
+        'Corporation|' . \Lang::trans('Corporation'),
+        'Institution|' . \Lang::trans('Institution'),
+        'Political Party|' . \Lang::trans('Political Party'),
+        'Township|' . \Lang::trans('Township'),
+        'Government|' . \Lang::trans('Government'),
+        'Public Community|' . \Lang::trans('Public Community')
     ];
 }
 


### PR DESCRIPTION
Currently registrant_types values may be translated using the Lang module. If translated, the translated equivalents will be passed to API instead.

Updated the registrant_types options to only show the translated version, when in fact using the English values in backend.