### PR TITLE
fix: use minimum year of the TLD instead of hardcoded one

### DIFF
--- a/nordname.php
+++ b/nordname.php
@@ -1225,10 +1225,10 @@ function nordname_GetTldPricing(array $params) {
             // Get each TLD info.
             $tld = $api->call("GET", "domain/tld/" . $tld, $getfields,"", $sandbox);
             
-            // If admin has set the setting to only set 1 year prices, override years array.
+            // If admin has set the setting to only set 1 year prices, override years array with minimum value of years.
             $registration_years = $tld["technical"]["registration_years"];
             if ($params["price_sync_one_year"] == "on") {
-                $registration_years = [1];
+                $registration_years = min($tld["technical"]["registration_years"]);
             }
             
             // Get reg, transfer and renew standard prices.


### PR DESCRIPTION
Currently, if admin selects the setting to allow customers register TLD only for one year, the one year is hardcoded to one year. How ever, if the TLD does not support one year registration, the minimum available registration time should be used.

This fixes the issue, using the TLD's minimum registration time, provided by the API.