### PR TITLE
fix: default nameservers in register call

### DIFF
--- a/nordname.php
+++ b/nordname.php
@@ -252,7 +252,7 @@ function nordname_RegisterDomain($params) {
         $getfields = array(
             'years' => $years,
             'auto_renew' => $auto_renew,
-            'nameservers' => array_values(array_filter($nameservers)),
+            'nameservers' => implode(",", array_filter($nameservers)),
             'registrant' => $registrant,
             'admin' => $params["auxiliary_contact"],
             'tech' => $params["auxiliary_contact"],


### PR DESCRIPTION
After most recent update, the format of nameservers on the RegisterDomain call was set to an incorrect one. It should be a comma-separated string of nameservers.